### PR TITLE
Escaping of “<”, “>” kept in XML

### DIFF
--- a/latex2mathml/converter.py
+++ b/latex2mathml/converter.py
@@ -14,19 +14,25 @@ from latex2mathml.commands import MATRICES, COMMANDS
 from latex2mathml.symbols_parser import convert_symbol
 
 
-def convert(latex):
+def convert(latex, unescaping = True):
     math = eTree.Element('math')
     row = eTree.SubElement(math, 'mrow')
     _classify_subgroup(aggregate(latex), row)
-    return _convert(math)
+    return _convert(math, unescaping)
 
 
-def _convert(tree):
+def _convert(tree, unescaping):
     xml_string = eTree.tostring(tree)
-    try:
-        return unescape(xml_string)
-    except TypeError:
-        return unescape(xml_string.decode('utf-8'))
+    if unescaping:
+        try:
+            return unescape(xml_string)
+        except TypeError:
+            return unescape(xml_string.decode('utf-8'))
+    else:
+        try:
+            return xml_string.decode('utf-8')
+        except AttributeError:
+            return xml_string
 
 
 def _convert_matrix_content(param, parent, alignment=None):


### PR DESCRIPTION
The change provides the possibility of having (or just: keeping) “<”, “>” escaped within the resulting XML.
*With and without this change:*
`convert('1 < 2')` yields `<math><mrow><mn>2</mn><mi><</mi><mn>4</mn></mrow></math>`, which is not well-formed XML. I cannot escape now, because the string already contains the XML tags. I also cannot escape the latex before, because `convert('1 &lt; 2')` leads to an undesired result.
*With this change:*
`convert('1 < 2', unescaping = False)` yields `<math><mrow><mn>2</mn><mi>&lt;</mi><mn>4</mn></mrow></math>`, which *is* well-formed XML.
Maybe the old behaviour is not even needed. The new code perhaps could be then:
```python
def _convert(tree):
    xml_string = eTree.tostring(tree)
    try:
        return xml_string.decode('utf-8')
    except AttributeError:
        return xml_string
```
without the parameter `unescaping` anywhere.